### PR TITLE
Update boot & deps filenames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ BOOT_IMAGE = $(PANDA_ROOT)/boot
 # The zipped file will be called this
 export GIT_VERSION_SUFFIX = \
     $(shell git describe --abbrev=7 --dirty --always --tags)
-BOOT_ZIP = $(PANDA_ROOT)/boot-$(GIT_VERSION_SUFFIX).zip
-DEPS_ZIP = $(PANDA_ROOT)/deps-$(GIT_VERSION_SUFFIX).zip
+BOOT_ZIP = $(PANDA_ROOT)/boot@$(PLATFORM)-$(GIT_VERSION_SUFFIX).zip
+DEPS_ZIP = $(PANDA_ROOT)/deps@$(PLATFORM)-$(GIT_VERSION_SUFFIX).zip
 
 # Tags for versions of u-boot and kernel
 U_BOOT_TAG = xilinx-v2020.2.2-k26


### PR DESCRIPTION
With the addition of CI, the output files will be automatically built and uploaded as artifacts for each platform. To distinguish between these files, the boot and deps zips will now include the target platform as part of the output filename.