### PR TITLE
Support block devices based on SCSI for zynqmp target

### DIFF
--- a/kernel/zynq.config
+++ b/kernel/zynq.config
@@ -1139,7 +1139,7 @@ CONFIG_SCSI_MOD=y
 CONFIG_SCSI_COMMON=y
 CONFIG_SCSI=y
 CONFIG_SCSI_DMA=y
-CONFIG_SCSI_PROC_FS=y
+# CONFIG_SCSI_PROC_FS is not set
 
 #
 # SCSI support type (disk, tape, CD-ROM)
@@ -1147,7 +1147,7 @@ CONFIG_SCSI_PROC_FS=y
 CONFIG_BLK_DEV_SD=y
 # CONFIG_CHR_DEV_ST is not set
 # CONFIG_BLK_DEV_SR is not set
-CONFIG_CHR_DEV_SG=y
+# CONFIG_CHR_DEV_SG is not set
 # CONFIG_BLK_DEV_BSG is not set
 # CONFIG_CHR_DEV_SCH is not set
 # CONFIG_SCSI_CONSTANTS is not set
@@ -1165,11 +1165,7 @@ CONFIG_CHR_DEV_SG=y
 # CONFIG_SCSI_SRP_ATTRS is not set
 # end of SCSI Transports
 
-CONFIG_SCSI_LOWLEVEL=y
-# CONFIG_ISCSI_TCP is not set
-# CONFIG_ISCSI_BOOT_SYSFS is not set
-# CONFIG_SCSI_DEBUG is not set
-# CONFIG_SCSI_VIRTIO is not set
+# CONFIG_SCSI_LOWLEVEL is not set
 # CONFIG_SCSI_DH is not set
 # end of SCSI device support
 

--- a/kernel/zynqmp.config
+++ b/kernel/zynqmp.config
@@ -1407,7 +1407,7 @@ CONFIG_SCSI_DMA=y
 #
 # SCSI support type (disk, tape, CD-ROM)
 #
-# CONFIG_BLK_DEV_SD is not set
+CONFIG_BLK_DEV_SD=y
 # CONFIG_CHR_DEV_ST is not set
 # CONFIG_BLK_DEV_SR is not set
 # CONFIG_CHR_DEV_SG is not set


### PR DESCRIPTION
The usb-storage driver needs this options to create the associated block device when we insert a usb memory stick.

Additionally, the zynq configuration was simplified to use the same SCSI related options (by removing unneeded ones)