### PR TITLE
Add lzop to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN yum -y upgrade && yum -y install \
     libmpc-devel \
     libjpeg-turbo-devel \
     libuuid-devel \
+    lzop \
     ncurses-compat-libs \
     openssl-devel \
     patch \


### PR DESCRIPTION
This is required for compression when a RootFS build is configured to make use of it.

More specifically, I'm trying to build the RootFS for a Colibri module. By adding this one requirement to the Dockerfile I can save myself having to build and maintain my own derivative version.