### PR TITLE
Add tini to container to fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,11 +107,8 @@ RUN cd "$RUNNER_ASSETS_DIR" \
     && unzip ./runner-container-hooks.zip -d ./k8s \
     && rm -f runner-container-hooks.zip
 
-# Add Tini
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
+# Add Tini to attach a zombie process subreaper to vivado jobs in container
+RUN yum -y install tini
 
 # Sets working directory
 WORKDIR /repos

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,6 +107,12 @@ RUN cd "$RUNNER_ASSETS_DIR" \
     && unzip ./runner-container-hooks.zip -d ./k8s \
     && rm -f runner-container-hooks.zip
 
+# Add Tini
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
 # Sets working directory
 WORKDIR /repos
 # Entrypoint into container


### PR DESCRIPTION
After make zpkg commands fail after Synthesis I found this post on stack overflow:
https://stackoverflow.com/questions/55733058/vivado-synthesis-hangs-in-docker-container-spawned-by-jenkins

which seemed to match the problem we have been encountering. When run in docker there is no PID 1 process which automatically cleans up zombie processes. This adds tini to the CI container which will clean up zombie processes. 

I have found adding this to the container and running the make zpkg command with tini running as a process subreaper fixes the problem.