### PR TITLE
Added note about SD format and location of files

### DIFF
--- a/docs/how-to/building.md
+++ b/docs/how-to/building.md
@@ -156,7 +156,7 @@ The boot process is as follows:
 
 To install a fresh PandA system:
 
-1. Obtain a formatted empty SD card. A minimum size of 2GB is recommended.
+1. Obtain a FAT32 formatted empty SD card. A minimum size of 2GB is recommended.
 
 2. Place the following files on the SD card (from rootfs build):
 
@@ -167,6 +167,9 @@ config.txt  imagefile.cpio.gz  uImage
 
 3. Allocate MAC address to target system. These need to be purchased in blocks.
 4. (Optionally) Write MAC address into a file named `MAC` on the SD card.
+
+> [!NOTE]
+> The files above are generated during the build process. If you are creating an SD card from release files you will need to include files from the latest release along with files from the 3.0 release.
 
 ## Panda System First Boot
 


### PR DESCRIPTION
Including information about how to format the SD card along with a note about where to find the files if not building from source.

This could also be broken into a new document but I figure there's a lot of overlap so it might as well be here.

This relates to https://github.com/PandABlocks/PandABlocks-rootfs/issues/73